### PR TITLE
[Widgets] Implemented displayName attribute for each widget properties.

### DIFF
--- a/src/js/adm.js
+++ b/src/js/adm.js
@@ -1872,6 +1872,18 @@ ADMNode.prototype.getPropertyDefault = function (property) {
 };
 
 /**
+ * Gets the display name for the named property for this widget type.
+ *
+ * @param {String} The name of the requested property.
+ * @return {Any} The default value of the property, or undefined if the
+ *               property is invalid for this object. The type returned depends
+ *               on the property.
+ */
+ADMNode.prototype.getPropertyDisplayName = function (property) {
+    return BWidget.getPropertyDisplayName(this.getType(), property);
+};
+
+/**
  * Returns whether the property is explicitly set or not. Properties that are
  * explicitly set should be serialized to disk.
  *

--- a/src/js/views/property.js
+++ b/src/js/views/property.js
@@ -129,7 +129,7 @@
             options = node.getPropertyOptions();
             // iterate property of node
             for (p in props) {
-                labelVal = p.replace(/_/g,'-');
+                labelVal = node.getPropertyDisplayName(p);
                 valueId = p+'-value';
                 valueVal = props[p];
                 propType = BWidget.getPropertyType(type, p);

--- a/src/js/widgets.js
+++ b/src/js/widgets.js
@@ -2005,6 +2005,29 @@ var BWidget = {
     },
 
     /**
+     * Gets the displayName for a given instance property.
+     *
+     * @param {String} widgetType The type of the widget.
+     * @param {String} property The name of the requested property.
+     * @return {AnyType} The default value for the given property, or
+     *                   undefined if this property has no default (in which
+     *                   case there should be an autoGenerate prefix set).
+     * @throws {Error} If widgetType is invalid, or property not found.
+     */
+    getPropertyDisplayName: function (widgetType, property) {
+        var stack = [], prop, widget = BWidgetRegistry[widgetType];
+        if (typeof widget !== "object") {
+            throw new Error(
+                "undefined widget type in getPropertyDisplayName: "
+                 + widgetType);
+        }
+        if (widget.properties && widget.properties[property]['displayName']) {
+            return widget.properties[property]['displayName'];
+        }
+        return property.replace(/_/g,'-');
+    },
+
+    /**
      * Gets the HTML attribute associated with this property.
      *
      * @param {String} widgetType The type of the widget.


### PR DESCRIPTION
In js/widgets.js there are some widget properties have displayName
attribute, it use for custom the label, but it is not functional.

See List.divider, OrderedList.divider, Collapsible.content_theme
and Accordion.content_theme in js/widgets.js.

The patch implemented the BWdiget.getPropertyDisplayName() to
make the attribute work.
