### PR TITLE
[Widgets] Support setting links to open pages as dialogs.

### DIFF
--- a/src/js/widgets.js
+++ b/src/js/widgets.js
@@ -459,6 +459,13 @@ var BWidgetRegistry = {
                 defaultValue: "",
                 htmlAttribute: "href"
             },
+            opentargetas : {
+                type: "string",
+                displayName: "open target as",
+                options: ["page", "dialog"],
+                defaultValue: "Page",
+                htmlAttribute: "data-rel",
+            },
             icon: {
                 type: "string",
                 options: [ "none", "alert", "arrow-d", "arrow-l", "arrow-r",


### PR DESCRIPTION
Added a Open Target As attribute to the button widget.
