### PR TITLE
[Widgets] Implemented displayName attribute for each widget properties.

### DIFF
--- a/src/js/adm.js
+++ b/src/js/adm.js
@@ -1872,6 +1872,17 @@ ADMNode.prototype.getPropertyDefault = function (property) {
 };
 
 /**
+ * Gets the display name for the named property for this widget type.
+ *
+ * @param {String} property The name of the requested property.
+ * @return {String} The display name of the property, or the property instance
+ *                  name if the property has no the attribute.
+ */
+ADMNode.prototype.getPropertyDisplayName = function (property) {
+    return BWidget.getPropertyDisplayName(this.getType(), property);
+};
+
+/**
  * Returns whether the property is explicitly set or not. Properties that are
  * explicitly set should be serialized to disk.
  *

--- a/src/js/views/property.js
+++ b/src/js/views/property.js
@@ -129,7 +129,7 @@
             options = node.getPropertyOptions();
             // iterate property of node
             for (p in props) {
-                labelVal = p.replace(/_/g,'-');
+                labelVal = node.getPropertyDisplayName(p);
                 valueId = p+'-value';
                 valueVal = props[p];
                 propType = BWidget.getPropertyType(type, p);

--- a/src/js/widgets.js
+++ b/src/js/widgets.js
@@ -2005,6 +2005,23 @@ var BWidget = {
     },
 
     /**
+     * Gets the display name for a given instance property.
+     *
+     * @param {String} widgetType The type of the widget.
+     * @param {String} property The name of the requested property.
+     * @return {String} The display name for the given property, or
+     *                  the property instance name if this property has
+     *                  no the attribute.
+     */
+    getPropertyDisplayName: function (widgetType, property) {
+        var schema = BWidget.getPropertySchema(widgetType, property);
+        if (schema && schema.displayName) {
+            return schema.displayName;
+        }
+        return property.replace(/_/g,'-');
+    },
+
+    /**
      * Gets the HTML attribute associated with this property.
      *
      * @param {String} widgetType The type of the widget.


### PR DESCRIPTION
In js/widgets.js there are some widget properties have displayName
attribute, it use for custom the label, but it is not functional.

See List.divider, OrderedList.divider, Collapsible.content_theme
and Accordion.content_theme in js/widgets.js.

The patch implemented the BWdiget.getPropertyDisplayName() to
make the attribute work.

UPDATE: Updated the code by John's comments.
