### PR TITLE
[Widgets] Fix boolean property values to use actual JS booleans

### DIFF
--- a/src/js/views/property.js
+++ b/src/js/views/property.js
@@ -147,10 +147,16 @@
                             .attr('id', valueId)
                             .appendTo(value);
 
+                        // FIXME: Boolean values should be actual booleans, not
+                        // "true" and "false" strings; but because of bugs we
+                        // had previously, data files were written out with the
+                        // wrong values, so the following test helps them keep
+                        // working correctly. Someday, we should remove it.
+
                         // initial value of checkbox
                         if ((node.getProperty (p) === true) ||
                             (node.getProperty (p) === "true")) {
-                            value.find("#" + valueId).attr("checked", true);
+                            value.find("#" + valueId).attr("checked", "checked");
                         }
                         break;
                     case "record-array":

--- a/src/js/widgets.js
+++ b/src/js/widgets.js
@@ -529,7 +529,7 @@ var BWidgetRegistry = {
             },
             inline: {
                 type: "boolean",
-                defaultValue: "false",
+                defaultValue: false,
                 htmlAttribute: "data-inline"
             },
             transition: {
@@ -1088,7 +1088,7 @@ var BWidgetRegistry = {
         properties: {
             inset: {
                 type: "boolean",
-                defaultValue: "true",
+                defaultValue: true,
                 htmlAttribute: "data-inset",
                 // because data-inset="false" is the real default, do this:
                 forceAttribute: true
@@ -1098,7 +1098,7 @@ var BWidgetRegistry = {
             },
             filter: {
                 type: "boolean",
-                defaultValue: "false",
+                defaultValue: false,
                 htmlAttribute: "data-filter"
             },
             theme: {
@@ -1136,7 +1136,7 @@ var BWidgetRegistry = {
         properties: {
             inset: {
                 type: "boolean",
-                defaultValue: "true",
+                defaultValue: true,
                 htmlAttribute: "data-inset",
                 // because data-inset="false" is the real default, do this:
                 forceAttribute: true
@@ -1146,7 +1146,7 @@ var BWidgetRegistry = {
             },
             filter: {
                 type: "boolean",
-                defaultValue: "false",
+                defaultValue: false,
                 htmlAttribute: "data-filter"
             },
             theme: {
@@ -1631,7 +1631,7 @@ var BWidgetRegistry = {
             },
             show_preview: {
                 type: "boolean",
-                defaultValue: "false",
+                defaultValue: false,
                 htmlAttribute: "data-show-preview"
             }
         },


### PR DESCRIPTION
Originally, we implemented boolean properties by using the "oneof" string property type [ "true", "false" ]. When we converted these to be a new "boolean" type, shown in the property view as a checkbox, we should have used actual JS boolean values true and false. But instead we had a mixture where some places we used a boolean and some places we used a string. Since the string "false" is JS "truthy", this caused some confusion and therefore bugs.

This patch fixes all the "defaultValue" settings to use actual booleans, so hopefully the pattern will stick. Note, you may have old design files that have recorded the invalid "true" and "false" settings. I believe thanks to some defensive code Shane had already added to property.js, these will still be read in properly.

I tested all the affected widgets and the properties seem to work correctly for me. I tried to look through all the code for getProperty calls that might be affected by this change and I don't think any have slipped through the cracks, but I thought I'd submit this as a PR for review in case someone else can find something.
