### PR TITLE
[Serialize] Remove unnecessary workaround for autogenerated properties

### DIFF
--- a/src/js/serialize.js
+++ b/src/js/serialize.js
@@ -19,7 +19,6 @@
  * General functions for two directions
  ******************************************************/
 var DEBUG = true,
-    blockModelUpdated = false,
     blockActivePageChanged = false,
     xmlserializer = new XMLSerializer(),
     formatHTML  = function (rawHTML) {
@@ -108,15 +107,7 @@ var DEBUG = true,
             }
         }
 
-        // The ADMNode.getProperties() call will trigger a modelUpdated
-        // event due to any property being set to autogenerate
-        node.suppressEvents(true);
-        node.getDesign().suppressEvents(true);
-
-        blockModelUpdated = true;
         props = node.getProperties();
-        id = node.getProperty('id');
-        blockModelUpdated = false;
 
         if (typeof template === "function") {
             widget = template(node);
@@ -205,10 +196,6 @@ var DEBUG = true,
                 $(domNodes[i]).remove();
             $(domNodes[0]).replaceWith(widget);
         }
-
-
-        node.getDesign().suppressEvents(false);
-        node.suppressEvents(false);
 
         return widget;
     },


### PR DESCRIPTION
Shane,

I wanted you to take a look at this, I haven't adequately tested it. If you can remember the case you were running into when you added this workaround it would be best to retest with that again. And just think about whether you had more reason for this than was listed in the comment. But I haven't seen a problem with it.
- Geoff

Commit message:
The commit "[ADM] Suppress events when autogenerating properties" made this
workaround unnecessary. Removing it simplifies the code here.
