### PR TITLE
[Serialize] Fix a bug that when template is a function, htmlAttribute doesn't take effect.

### DIFF
--- a/src/js/serialize.js
+++ b/src/js/serialize.js
@@ -60,7 +60,7 @@ var DEBUG = true,
             return null;
         }
 
-        template = BWidget.getTemplate(node.getType());
+        template = BWidget.getTemplate(node);
 
         // 1. Regenerating the entire Design, re-create entire document
         if (node.instanceOf('Design')) {
@@ -109,10 +109,7 @@ var DEBUG = true,
 
         props = node.getProperties();
 
-        if (typeof template === "function") {
-            widget = template(node);
-        }
-        else {
+        {
             if (typeof template === "object") {
                 template = template[props["type"]];
             }

--- a/src/js/views/palette.js
+++ b/src/js/views/palette.js
@@ -62,7 +62,6 @@
                                 .appendTo(container);
                             $(li).disableSelection()
                                 .addClass('nrc-palette-widget')
-                                .data("code", BWidget.getTemplate(value))
                                 .data("adm-node", {type: value});
                         }
                     }

--- a/src/js/widgets.js
+++ b/src/js/widgets.js
@@ -2340,15 +2340,14 @@ var BWidget = {
     /**
      * Gets the template for a given widget type.
      *
-     * @param {String} widgetType The type of the widget.
+     * @param {ADMNode} node The ADMNode to get template from.
      * @return {Various} The template string for this widget type, or an
-     *                   object (FIXME: explain), or a function(ADMNode) that
-     *                   provides a template, or undefined if the template does
-     *                   not exist.
+     *                   object (FIXME: explain) that provides a template,
+     *                   or undefined if the template does not exist.
      * @throws {Error} If widgetType is invalid.
      */
-    getTemplate: function (widgetType) {
-        var widget, template;
+    getTemplate: function (node) {
+        var widget, template, widgetType = node.getType();
         widget = BWidgetRegistry[widgetType];
         if (typeof widget !== "object") {
             throw new Error("undefined widget type in getTemplate: " +
@@ -2360,6 +2359,8 @@ var BWidget = {
             typeof template !== "function") {
             return "";
         }
+        if (typeof template === "function")
+            template = new XMLSerializer().serializeToString(template(node)[0]);
         return template;
     },
 


### PR DESCRIPTION
Note: image-tag is dependent on this submission.

The root cause of this bug is that in serailize.js, when template
is a function, widget is generated without applying html
attributes. To simplify the logic, I refactor the getTemplate
fucntion so that it only retures string or object. Note that in
palette.js, the "code" data is not used by any other code so I
delete the line setting the "code" data.
