### PR TITLE
Fixed a background image bug

### DIFF
--- a/src/js/widgets.js
+++ b/src/js/widgets.js
@@ -222,9 +222,9 @@ var BWidgetRegistry = {
                     name: "style",
                     value: function (propValue) {
                         return "background-image:url('" + propValue + "');" +
-                            "background-attachment:scroll;" +
+                            "background-attachment:fixed;" +
                             "background-repeat:no-repeat;" +
-                            "background-size:cover;";
+                            "background-size:100% 100%;";
                     }
                 }
             }


### PR DESCRIPTION
[Widgets] Fixed Bug: The background image resizes upon insertion of many widgets, distorting itself
Description
# EXACT STEPS LEADING TO PROBLEM:
1. Open RIB.
2. Specify a link pointing to an image in the background input of the page.
3. Insert lots of widgets.
   ACTUAL OUTCOME:
   ===================
   The background image keeps resizing, distorting itself.
   EXPECTED OUTCOME:
   ===================
   The image should be fixed.
