### PR TITLE
[ADM] Implemented propertyVisible() for widget property exposed to user.

### DIFF
--- a/src/js/views/property.js
+++ b/src/js/views/property.js
@@ -130,6 +130,9 @@
             options = node.getPropertyOptions();
             // iterate property of node
             for (p in props) {
+                if (!BWidget.propertyVisible(node.getType(), p)) {
+                    continue;
+                }
                 labelVal = node.getPropertyDisplayName(p);
                 valueId = p+'-value';
                 valueVal = props[p];

--- a/src/js/widgets.js
+++ b/src/js/widgets.js
@@ -160,6 +160,8 @@ var BCommonProperties = {
  *   9)        validIn:  Parent widget in which this property is valid
  *
  *  10)      invalidIn:  Parent widget in which this property is not valid
+ *  11)        visible:  optional boolean for the property user-exposed in
+ *                       property view (default true)
  *
  * @class
  */
@@ -2298,6 +2300,26 @@ var BWidget = {
             return true;
         }
         return schema;
+    },
+
+
+    /**
+     * Tests whether this property is visible to user, for example, property
+     * view can use it to decide if it will show this property.
+     *
+     * @param {String} widgetType The type of the widget.
+     * @param {String} property The name of the requested property.
+     * @return {Boolean} true if this property is visible to user, or it is
+     *                   undefined.
+     *                   false if this property is invisible to user.
+     */
+    propertyVisible: function (widgetType, property) {
+        var schema = BWidget.getPropertySchema(widgetType, property);
+        if (schema && typeof(schema.visible) == 'boolean') {
+            return schema.visible;
+        } else {
+            return true;
+        }
     },
 
     /**


### PR DESCRIPTION
The function will determine the property whether to show in property view.

Replace #131 & #141 by @zhizhangchen's comments.

@grgustaf Because of propertyUserVisible is too long and hard to fit the size of docs in widgets.js, so I still use 'propertyVisible' as the function and attribute name.
