### PR TITLE
[Widgets] Fix select menu init problem

### DIFF
--- a/src/js/widgets.js
+++ b/src/js/widgets.js
@@ -1024,6 +1024,7 @@ var BWidgetRegistry = {
                 optionItem.value = "Value";
                 prop.children.push(optionItem);
             }
+            node.setProperty("options", prop);
         },
         displayLabel: "Select Menu",
         properties: {


### PR DESCRIPTION
Previous init code set property directly without calling
setProperty. Now that getProperty returns a copy of the property,
we should call setProperty instead of changing the returned
property object to set a property.
