### PR TITLE
[FixBug] Selected check-box loses green box after changing tab

### DIFF
--- a/src/js/composer.js
+++ b/src/js/composer.js
@@ -442,6 +442,11 @@ $(function() {
                 if (events) {
                     $(node).bind(events);
                 }
+                // If this node is "selected", make sure it's class reflects this
+                if (admNode.isSelected() && !admNode.instanceOf('Page')) {
+                    setSelected(delegateNode);
+                }
+
             }
         });
 
@@ -521,7 +526,6 @@ $(function() {
         targets = $(e.target).subtree('.nrc-sortable-container');
 
         debug && console.log("Found ["+targets.length+"] sortable targets: ");
-
         targets
             .sortable({
                 distance: 5,

--- a/src/js/views/layout.js
+++ b/src/js/views/layout.js
@@ -379,11 +379,6 @@
 
             $(domNode).addClass('adm-node');
 
-            // If this node is "selected", make sure it's class reflects this
-            if (admNode.isSelected() && !admNode.instanceOf('Page')) {
-                $(domNode).addClass('ui-selected');
-            }
-
             // If this node is a "container", make sure it's class reflects this
             if (admNode.isContainer()) {
                 $(domNode).addClass('nrc-sortable-container');


### PR DESCRIPTION
Bug description:
Selected check-box, toggle-switch or radio button in layout view,
then change to other tab, such as preview, then change back to
layout view, the green box around the selected item will disappear.
